### PR TITLE
Android: crash on startup with 1.0.6.1 (and earlier)

### DIFF
--- a/Mvx.Geocoder.Droid/DroidGeocoder.cs
+++ b/Mvx.Geocoder.Droid/DroidGeocoder.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 
-namespace Mvx.Geocoder.Droid
+namespace MvvmCross.HotTuna.Plugins.Geocoder.Droid
 {
     public class DroidGeocoder : IGeocoder
     {

--- a/Mvx.Geocoder.Droid/Mvx.Geocoder.Droid.csproj
+++ b/Mvx.Geocoder.Droid/Mvx.Geocoder.Droid.csproj
@@ -6,13 +6,13 @@
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{62F3258C-1E53-4510-BF27-E3AA0D355F2E}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Mvx.Geocoder.Droid</RootNamespace>
+    <RootNamespace>MvvmCross.HotTuna.Plugins.Geocoder.Droid</RootNamespace>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <AssemblyName>Mvx.Geocoder.Droid</AssemblyName>
+    <AssemblyName>MvvmCross.HotTuna.Plugins.Geocoder.Droid</AssemblyName>
     <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Mvx.Geocoder.Droid/Plugin.cs
+++ b/Mvx.Geocoder.Droid/Plugin.cs
@@ -1,6 +1,6 @@
 ﻿using Cirrious.CrossCore.Plugins;
 
-namespace Mvx.Geocoder.Droid
+namespace MvvmCross.HotTuna.Plugins.Geocoder.Droid
 {
     public class Plugin
         : IMvxPlugin

--- a/Mvx.Geocoder.Touch/Mvx.Geocoder.Touch.csproj
+++ b/Mvx.Geocoder.Touch/Mvx.Geocoder.Touch.csproj
@@ -6,9 +6,9 @@
     <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{9F0CEBBB-FD18-47DB-95EE-D87A5689F2D8}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Mvx.Geocoder.Touch</RootNamespace>
+    <RootNamespace>MvvmCross.HotTuna.Plugins.Geocoder.Touch</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <AssemblyName>Mvx.Geocoder.Touch</AssemblyName>
+    <AssemblyName>MvvmCross.HotTuna.Plugins.Geocoder.Touch</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/Mvx.Geocoder.Touch/Plugin.cs
+++ b/Mvx.Geocoder.Touch/Plugin.cs
@@ -1,6 +1,6 @@
 ﻿using Cirrious.CrossCore.Plugins;
 
-namespace Mvx.Geocoder.Touch
+namespace MvvmCross.HotTuna.Plugins.Geocoder.Touch
 {
     public class Plugin
         : IMvxPlugin

--- a/Mvx.Geocoder.Touch/TouchGeocoder.cs
+++ b/Mvx.Geocoder.Touch/TouchGeocoder.cs
@@ -4,7 +4,7 @@ using MonoTouch.AddressBook;
 using MonoTouch.CoreLocation;
 using MonoTouch.Foundation;
 
-namespace Mvx.Geocoder.Touch
+namespace MvvmCross.HotTuna.Plugins.Geocoder.Touch
 {
     public class TouchGeocoder : IGeocoder
     {

--- a/Mvx.Geocoder.WindowsPhone/AsyncQueryExtension.cs
+++ b/Mvx.Geocoder.WindowsPhone/AsyncQueryExtension.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Phone.Maps.Services;
+
+namespace MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone
+{
+    public static class AsyncQueryExtension
+    {
+        // Props to http://compiledexperience.com/blog/posts/async-geocode-query/ for the generic version
+        public static Task<T> ExecuteAsync<T>(this Query<T> query)
+        {
+            var taskSource = new TaskCompletionSource<T>();
+
+            EventHandler<QueryCompletedEventArgs<T>> handler = null;
+
+            handler = (s, e) =>
+            {
+                query.QueryCompleted -= handler;
+
+                if (e.Cancelled)
+                {
+                    taskSource.SetCanceled();
+                }
+                else if (e.Error != null)
+                {
+                    taskSource.SetException(e.Error);
+                }
+                else
+                {
+                    taskSource.SetResult(e.Result);
+                }
+            };
+
+            query.QueryCompleted += handler;
+            query.QueryAsync();
+
+            return taskSource.Task;
+        }
+    }
+}

--- a/Mvx.Geocoder.WindowsPhone/Mvx.Geocoder.WindowsPhone.csproj
+++ b/Mvx.Geocoder.WindowsPhone/Mvx.Geocoder.WindowsPhone.csproj
@@ -9,8 +9,8 @@
     <ProjectTypeGuids>{C089C8C0-30E0-4E22-80C0-CE093F111A43};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Mvx.Geocoder.WindowsPhone</RootNamespace>
-    <AssemblyName>Mvx.Geocoder.WindowsPhone</AssemblyName>
+    <RootNamespace>MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone</RootNamespace>
+    <AssemblyName>MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone</AssemblyName>
     <TargetFrameworkIdentifier>WindowsPhone</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>

--- a/Mvx.Geocoder.WindowsPhone/Plugin.cs
+++ b/Mvx.Geocoder.WindowsPhone/Plugin.cs
@@ -1,6 +1,6 @@
 ﻿using Cirrious.CrossCore.Plugins;
 
-namespace Mvx.Geocoder.WindowsPhone
+namespace MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone
 {
     public class Plugin : IMvxPlugin
     {

--- a/Mvx.Geocoder.WindowsPhone/WindowsPhoneGeocoder.cs
+++ b/Mvx.Geocoder.WindowsPhone/WindowsPhoneGeocoder.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Phone.Maps.Services;
 
-namespace Mvx.Geocoder.WindowsPhone
+namespace MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone
 {
     public class WindowsPhoneGeocoder : IGeocoder
     {

--- a/Mvx.Geocoder.sln
+++ b/Mvx.Geocoder.sln
@@ -11,6 +11,24 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvx.Geocoder.Droid", "Mvx.G
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvx.Geocoder.WindowsPhone", "Mvx.Geocoder.WindowsPhone\Mvx.Geocoder.WindowsPhone.csproj", "{55063605-809A-4E0D-82A5-754F2ECAB9AD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuspec", "nuspec", "{68BE70A5-FFAE-4CE0-9318-CC87F4121119}"
+	ProjectSection(SolutionItems) = preProject
+		nuspec\Mvx.Plugins.Geocoder.nuspec = nuspec\Mvx.Plugins.Geocoder.nuspec
+		nuspec\Mvx.Plugins.Geocoder.Windows.nuspec = nuspec\Mvx.Plugins.Geocoder.Windows.nuspec
+		nuspec\pack.sh = nuspec\pack.sh
+		nuspec\push.sh = nuspec\push.sh
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BootstrapContent", "BootstrapContent", "{E5D6699C-D0E2-4D0C-86F5-AD0CD995FF9D}"
+	ProjectSection(SolutionItems) = preProject
+		nuspec\BootstrapContent\GeocoderPluginBootstrap.cs.pp = nuspec\BootstrapContent\GeocoderPluginBootstrap.cs.pp
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TouchBootstrapContent", "TouchBootstrapContent", "{5C39F976-E622-4062-8DC4-2D7760D461DF}"
+	ProjectSection(SolutionItems) = preProject
+		nuspec\TouchBootstrapContent\GeocoderPluginBootstrap.cs.pp = nuspec\TouchBootstrapContent\GeocoderPluginBootstrap.cs.pp
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +99,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E5D6699C-D0E2-4D0C-86F5-AD0CD995FF9D} = {68BE70A5-FFAE-4CE0-9318-CC87F4121119}
+		{5C39F976-E622-4062-8DC4-2D7760D461DF} = {68BE70A5-FFAE-4CE0-9318-CC87F4121119}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Mvx.Geocoder\Mvx.Geocoder.csproj

--- a/Mvx.Geocoder/Address.cs
+++ b/Mvx.Geocoder/Address.cs
@@ -1,4 +1,4 @@
-﻿namespace Mvx.Geocoder
+﻿namespace MvvmCross.HotTuna.Plugins.Geocoder
 {
 	public class Address
 	{

--- a/Mvx.Geocoder/IGeocoder.cs
+++ b/Mvx.Geocoder/IGeocoder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace Mvx.Geocoder
+namespace MvvmCross.HotTuna.Plugins.Geocoder
 {
 	public interface IGeocoder
 	{

--- a/Mvx.Geocoder/Mvx.Geocoder.csproj
+++ b/Mvx.Geocoder/Mvx.Geocoder.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -6,8 +6,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{8B2B460C-7F28-43C7-A017-A9C17A47FFDC}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Mvx.Geocoder</RootNamespace>
-    <AssemblyName>Mvx.Geocoder</AssemblyName>
+    <RootNamespace>MvvmCross.HotTuna.Plugins.Geocoder</RootNamespace>
+    <AssemblyName>MvvmCross.HotTuna.Plugins.Geocoder</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile158</TargetFrameworkProfile>
   </PropertyGroup>

--- a/Mvx.Geocoder/PluginLoader.cs
+++ b/Mvx.Geocoder/PluginLoader.cs
@@ -1,6 +1,6 @@
 ﻿using Cirrious.CrossCore.Plugins;
 
-namespace Mvx.Geocoder
+namespace MvvmCross.HotTuna.Plugins.Geocoder
 {
 	public class PluginLoader: IMvxPluginLoader
 	{

--- a/nuspec/Mvx.Plugins.Geocoder.Windows.nuspec
+++ b/nuspec/Mvx.Plugins.Geocoder.Windows.nuspec
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-	<metadata>
-		<id>Mvx.Plugins.Geocoder</id>
-		<version>1.0.6.3</version>
-		<title>MvvmCross - Geocoder Plugin</title>
-		<authors>SeeD-Seifer</authors>
-		<owners>SeeD-Seifer</owners>
-		<licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
-		<projectUrl>https://github.com/SeeD-Seifer/Mvx.Geocoder</projectUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<description>This package contains the 'Geocoder' plugin for MvvmCross v3 - Hot Tuna.</description>
-		<tags>mvvm mvvmcross xamarin monodroid monotouch wpf windows8 winrt netcore wp wpdev windowsphone</tags>
-		<dependencies>
-		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.1.1" />
-		</dependencies>
-	</metadata>
-	<files>		
-		<!-- PCL -->
-		<file src="..\Mvx.Geocoder\bin\Release\Mvx.Geocoder.dll" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+MonoTouch\Mvx.Geocoder.dll" />
+  <metadata>
+    <id>Mvx.Plugins.Geocoder</id>
+    <version>1.0.7</version>
+    <title>MvvmCross - Geocoder Plugin</title>
+    <authors>SeeD-Seifer</authors>
+    <owners>SeeD-Seifer</owners>
+    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>https://github.com/SeeD-Seifer/Mvx.Geocoder</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>This package contains the 'Geocoder' plugin for MvvmCross v3 - Hot Tuna.</description>
+    <tags>mvvm mvvmcross xamarin monodroid monotouch wpf windows8 winrt netcore wp wpdev windowsphone</tags>
+    <dependencies>
+      <dependency id="MvvmCross.HotTuna.CrossCore" version="3.1.1" />
+    </dependencies>
+  </metadata>
+  <files>
+    <!-- PCL -->
+    <file src="..\Mvx.Geocoder\bin\Release\MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+MonoTouch\MvvmCross.HotTuna.Plugins.Geocoder.dll" />
 
-		<!-- droid -->
-		<file src="..\Mvx.Geocoder\bin\Release\Mvx.Geocoder.dll" target="lib\MonoAndroid\Mvx.Geocoder.dll" />
-		<file src="..\Mvx.Geocoder.Droid\bin\Release\Mvx.Geocoder.Droid.dll" target="lib\MonoAndroid\Mvx.Geocoder.Droid.dll" />
-        <file src="BootstrapContent\GeocoderPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\GeocoderPluginBootstrap.cs.pp" />
+    <!-- droid -->
+    <file src="..\Mvx.Geocoder\bin\Release\MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib\MonoAndroid\MvvmCross.HotTuna.Plugins.Geocoder.dll" />
+    <file src="..\Mvx.Geocoder.Droid\bin\Release\MvvmCross.HotTuna.Plugins.Geocoder.Droid.dll" target="lib\MonoAndroid\MvvmCross.HotTuna.Plugins.Geocoder.Droid.dll" />
+    <file src="BootstrapContent\GeocoderPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\GeocoderPluginBootstrap.cs.pp" />
 
-		<!-- touch -->
-		<file src="..\Mvx.Geocoder\bin\Release\Mvx.Geocoder.dll" target="lib\MonoTouch\Mvx.Geocoder.dll" />
-		<file src="..\Mvx.Geocoder.Touch/bin/Release/Mvx.Geocoder.Touch.dll" target="lib\MonoTouch\Mvx.Geocoder.Touch.dll" />
-		<file src="TouchBootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content\MonoTouch\Bootstrap\GeocoderPluginBootstrap.cs.pp" />
+    <!-- touch -->
+    <file src="..\Mvx.Geocoder\bin\Release\MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib\MonoTouch\MvvmCross.HotTuna.Plugins.Geocoder.dll" />
+    <file src="..\Mvx.Geocoder.Touch/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.Touch.dll" target="lib\MonoTouch\MvvmCross.HotTuna.Plugins.Geocoder.Touch.dll" />
+    <file src="TouchBootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content\MonoTouch\Bootstrap\GeocoderPluginBootstrap.cs.pp" />
 
-		<!-- phone -->
-		<file src="..\Mvx.Geocoder\bin\Release\Mvx.Geocoder.dll" target="lib\wp8\Mvx.Geocoder.dll" />
-		<file src="..\Mvx.Geocoder.WindowsPhone\bin\Release\Mvx.Geocoder.WindowsPhone.dll" target="lib\wp8\Mvx.Geocoder.WindowsPhone.dll" />
-		<file src="WindowsPhoneBootstrapContent\GeocoderPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\GeocoderPluginBootstrap.cs.pp" />
-	</files>
+    <!-- phone -->
+    <file src="..\Mvx.Geocoder\bin\Release\MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib\wp8\MvvmCross.HotTuna.Plugins.Geocoder.dll" />
+    <file src="..\Mvx.Geocoder.WindowsPhone\bin\Release\MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone.dll" target="lib\wp8\MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone.dll" />
+    <file src="BootstrapContent\GeocoderPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\GeocoderPluginBootstrap.cs.pp" />
+  </files>
 </package>

--- a/nuspec/Mvx.Plugins.Geocoder.nuspec
+++ b/nuspec/Mvx.Plugins.Geocoder.nuspec
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-	<metadata>
-		<id>Mvx.Plugins.Geocoder</id>
-		<version>1.0.6.3</version>
-		<title>MvvmCross - Geocoder Plugin</title>
-		<authors>SeeD-Seifer</authors>
-		<owners>SeeD-Seifer</owners>
-		<licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
-		<projectUrl>https://github.com/SeeD-Seifer/Mvx.Geocoder</projectUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<description>This package contains the 'Geocoder' plugin for MvvmCross v3 - Hot Tuna.</description>
-		<tags>mvvm mvvmcross xamarin monodroid monotouch wpf windows8 winrt netcore wp wpdev windowsphone</tags>
-		<dependencies>
-		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.1.1" />
-		</dependencies>
-	</metadata>
-	<files>		
-		<!-- PCL -->
-		<file src="../Mvx.Geocoder/bin/Release/Mvx.Geocoder.dll" target="lib/portable-win+net45+sl50+wp8+MonoAndroid+MonoTouch/Mvx.Geocoder.dll" />
+  <metadata>
+    <id>Mvx.Plugins.Geocoder</id>
+    <version>1.0.7</version>
+    <title>MvvmCross - Geocoder Plugin</title>
+    <authors>SeeD-Seifer</authors>
+    <owners>SeeD-Seifer</owners>
+    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>https://github.com/SeeD-Seifer/Mvx.Geocoder</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>This package contains the 'Geocoder' plugin for MvvmCross v3 - Hot Tuna.</description>
+    <tags>mvvm mvvmcross xamarin monodroid monotouch wpf windows8 winrt netcore wp wpdev windowsphone</tags>
+    <dependencies>
+      <dependency id="MvvmCross.HotTuna.CrossCore" version="3.1.1" />
+    </dependencies>
+  </metadata>
+  <files>
+    <!-- PCL -->
+    <file src="../Mvx.Geocoder/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib/portable-win+net45+sl50+wp8+MonoAndroid+MonoTouch/MvvmCross.HotTuna.Plugins.Geocoder.dll" />
 
-		<!-- droid -->
-		<file src="../Mvx.Geocoder/bin/Release/Mvx.Geocoder.dll" target="lib/MonoAndroid/Mvx.Geocoder.dll" />
-		<file src="../Mvx.Geocoder.Droid/bin/Release/Mvx.Geocoder.Droid.dll" target="lib/MonoAndroid/Mvx.Geocoder.Droid.dll" />
-        <file src="BootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content/MonoAndroid/Bootstrap/GeocoderPluginBootstrap.cs.pp" />
+    <!-- droid -->
+    <file src="../Mvx.Geocoder/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib/MonoAndroid/MvvmCross.HotTuna.Plugins.Geocoder.dll" />
+    <file src="../Mvx.Geocoder.Droid/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.Droid.dll" target="lib/MonoAndroid/MvvmCross.HotTuna.Plugins.Geocoder.Droid.dll" />
+    <file src="BootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content/MonoAndroid/Bootstrap/GeocoderPluginBootstrap.cs.pp" />
 
-		<!-- touch -->
-		<file src="../Mvx.Geocoder/bin/Release/Mvx.Geocoder.dll" target="lib/MonoTouch/Mvx.Geocoder.dll" />
-		<file src="../Mvx.Geocoder.Touch/bin/Release/Mvx.Geocoder.Touch.dll" target="lib/MonoTouch/Mvx.Geocoder.Touch.dll" />
-		<file src="TouchBootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content/MonoTouch/Bootstrap/GeocoderPluginBootstrap.cs.pp" />
+    <!-- touch -->
+    <file src="../Mvx.Geocoder/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib/MonoTouch/MvvmCross.HotTuna.Plugins.Geocoder.dll" />
+    <file src="../Mvx.Geocoder.Touch/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.Touch.dll" target="lib/MonoTouch/MvvmCross.HotTuna.Plugins.Geocoder.Touch.dll" />
+    <file src="TouchBootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content/MonoTouch/Bootstrap/GeocoderPluginBootstrap.cs.pp" />
 
-		<!-- phone -->
-		<file src="../Mvx.Geocoder/bin/Release/Mvx.Geocoder.dll" target="lib/wp8/Mvx.Geocoder.dll" />
-		<file src="../Mvx.Geocoder.WindowsPhone/bin/Release/Mvx.Geocoder.WindowsPhone.dll" target="lib/wp8/Mvx.Geocoder.WindowsPhone.dll" />
-		<file src="WindowsPhoneBootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content/wp8/Bootstrap/GeocoderPluginBootstrap.cs.pp" />
-	</files>
+    <!-- phone -->
+    <file src="../Mvx.Geocoder/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.dll" target="lib/wp8/MvvmCross.HotTuna.Plugins.Geocoder.dll" />
+    <file src="../Mvx.Geocoder.WindowsPhone/bin/Release/MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone.dll" target="lib/wp8/MvvmCross.HotTuna.Plugins.Geocoder.WindowsPhone.dll" />
+    <file src="BootstrapContent/GeocoderPluginBootstrap.cs.pp" target="content/wp8/Bootstrap/GeocoderPluginBootstrap.cs.pp" />
+  </files>
 </package>

--- a/nuspec/WindowsPhoneBootstrapContent/GeocoderPluginBootstrap.cs.pp
+++ b/nuspec/WindowsPhoneBootstrapContent/GeocoderPluginBootstrap.cs.pp
@@ -1,8 +1,0 @@
-using Cirrious.CrossCore.Plugins;
-
-namespace $rootnamespace$.Bootstrap
-{
-	public class GeocoderPluginBootstrap : MvxPluginBootstrapAction<MvxPlugins.Geocoder.PluginLoader>
-	{
-	}
-}


### PR DESCRIPTION
After updating my app project to the newest available version of the plugin, MvvmCross' initialization dies due to an unhandled exception.

I figured this out back when I was making the WP version: Mvx tries to find the plugin assembly using the namespace of the Plugin C# class (MvxPlugins.Geocoder.Droid), while the file was built differently (Mvx.Geocoder.Droid).

There are two simple fixes for it: either rename the namespace to match the assembly, or vica versa. I opted for the latter, as seen in this pull request.

(I actually did this weeks ago for my custom package, but forgot to share.)
